### PR TITLE
Added redirect to dashboard error page if response from api has a res…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Added redirect to dashboard error page if response from api has a response.error.code and it's not 200.
 <!-- Unreleased changes can be added here. -->
 
 ## 1.0.15

--- a/src/assets/js/FormsQuestions.js
+++ b/src/assets/js/FormsQuestions.js
@@ -875,10 +875,11 @@ export default {
           }
         };
         fetch(`${process.env.VUE_APP_API_ROOT}${process.env.VUE_APP_REQUEST_URL}/${this.$store.state.global_params['requestId']}`, options)
-          .then(async response => {
-            const answers = await response.json();
+          .then(r => r.json())
+          .then((answers) => {
+            this.checkApiResponse(answers)
             if(answers.error){
-              return {}
+                return {}
             }
             this.valueHistory = []
             this.values = answers.form_data;

--- a/src/components/TimeoutWarning.vue
+++ b/src/components/TimeoutWarning.vue
@@ -97,7 +97,8 @@
         };
         fetch(`${process.env.VUE_APP_API_ROOT}/token/refresh`, options)
         .then(r => r.json())
-        .then(({ token }) => {
+        .then((response, { token }) => {
+          this.checkApiResponse(response)
           clearInterval(this.interval);
           this.interval = false;
           localStorage.setItem('auth-token', token);


### PR DESCRIPTION
# Description
Added redirect to dashboard error page if response from api has a response.error.code and it's not 200.

## Issue
https://bugs.earthdata.nasa.gov/browse/EDPUB-703

## Validation

### To Validate

1. Make sure all merge request checks have passed (CI/CD).
1. Pull branch locally.
1. In the forms code base, alter the fetchDaacs function to have the below, right before the 'this.checkApiResponse(data)' line.
``` javascript
data = {
            "success": false,
            "body": {},
            "error": {
              "code": 503, 
              "message": "An error occurred!"
            }
        } 
1. Alter the above declaration of data to be 'let' instead of 'const'.
1. From forms repo run 'npm run start' to start the api, forms and dashboard (Make sure forms re-builds).
1. Log into the dashboard as 'Earthdata Pub System'.
1. From the home page, click the 'New Request' button.
1. Verify you are routed to the dashboard's generic error page.
1. Revert the code back to where it was.
1. In your browser, navigate back to http://localhost:3000/
1. Click the 'New Request' button and verify you are routed to the forms daac selection page as normal.
1. Select any daac and click the 'Select' button.
1. Click the 'Dashboard' link in the header and choose to navigate back to the Dashboard.
1. Click on the request's 'Next Action' button.
1. Fill out the first field and click the 'Save as Draft' button.
1. Verify the form saves the data and reroutes you like before.

## Change Log

- [X] [Added redirect to dashboard error page if response from api has a response.error.code and it's not 200.](d0bf8dc6ef883bf12ef265fb4111069c23644d1f)