### PR TITLE
add support for token refresh on upload

### DIFF
--- a/src/assets/js/FormsQuestions.js
+++ b/src/assets/js/FormsQuestions.js
@@ -51,7 +51,7 @@ export default {
           }
         }, {
           key:'sha256Checksum',
-          label:'sha256Checksum', 
+          label:'sha256Checksum',
         }, {
           key: 'lastModified',
           label: 'Last Modified',
@@ -1034,11 +1034,11 @@ export default {
                 return
               }
             }
-  
+
             const files = resp
-            
+
             files.sort(function (a, b) {
-              var keyA = new Date(a.lastModified), 
+              var keyA = new Date(a.lastModified),
                 keyB = new Date(b.lastModified);
               if (keyA > keyB) return -1;
               if (keyA < keyB) return 1;
@@ -1075,6 +1075,21 @@ export default {
       return valid;
     },
 
+    async refreshAutth(){
+      const options = {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('auth-token')}`
+        }
+      };
+      await fetch(`${process.env.VUE_APP_API_ROOT}/token/refresh`, options)
+      .then(r => r.json())
+      .then(( { token }) => {
+        console.log('from refresh', token)
+        localStorage.setItem('auth-token', token);
+        this.$store.commit("setToken", token);
+      });
+    },
+
     async uploadFiles(event, controlId){
       const file = event.target.files[0]
       this.uploadQuestionId = controlId;
@@ -1083,23 +1098,24 @@ export default {
 
       if (this.validateFile(file, controlId)) {
         this.uploadStatusMsg = 'Uploading';
-        
+
         const upload = new localUpload();
         const requestId = this.$store.state.global_params['requestId'];
         try {
+          await this.refreshAutth();
           let payload = {
             fileObj: file,
             authToken: localStorage.getItem('auth-token'),
-          }          
+          }
           if (requestId !== '' && requestId != undefined && requestId !== null) {
             payload['apiEndpoint'] = `${process.env.VUE_APP_API_ROOT}/data/upload/getPostUrl`;
             payload['submissionId'] = requestId
-          } 
+          }
           const resp = await upload.uploadFile(payload)
           let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error
           if (error) {
             alertMsg = `An error has occured on uploadFile: ${error}.`;
-            statusMsg = `Select a file`;  
+            statusMsg = `Select a file`;
             // eslint-disable-next-line
             console.log(`An error has occured on uploadFile: ${error}.`);
             this.resetUploads(alertMsg, statusMsg, controlId);
@@ -1120,7 +1136,7 @@ export default {
           statusMsg = `Select a file`
           this.resetUploads(alertMsg, statusMsg, controlId);
         }
-      } 
+      }
     }
   },
   beforeUnmount() {


### PR DESCRIPTION
# Description

add support for updating the auth token on upload

## Spec

See Ticket: [EDPUB-1239](https://bugs.earthdata.nasa.gov/browse/EDPUB-1239)

---

## Validation
PR paired with:https://github.com/eosdis-nasa/earthdata-pub-dashboard/pull/48 

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a submission.
4. Using inspect element check the bearer token of any api call and take a not of part of the token.
5. Try to upload a file using the dashboard.(this should fail)
6. Confirm the bearer token used to upload is different than the one noted earlier.
7. Try to upload a file in the forms.(this should fail)
8. Confirm the bearer token used to upload is different than both tokens user earlier.

---

## Change Log

add support for updating the auth token on upload

* [Add _____](link to commitid)
* [Fix _____](link to commitid)